### PR TITLE
feat: standaard alleen open meldingen, optioneel recent gesloten

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -10,8 +10,9 @@ export async function fetchTemplates() {
   return res.json();
 }
 
-export async function fetchIssues(repo) {
-  const res = await fetch(`/api/repos/${encodeURIComponent(repo)}/issues`);
+export async function fetchIssues(repo, { recentClosed = false } = {}) {
+  const q = recentClosed ? '?recentClosed=1' : '';
+  const res = await fetch(`/api/repos/${encodeURIComponent(repo)}/issues${q}`);
   if (!res.ok) throw new Error((await res.json()).error || 'Issues ophalen mislukt');
   return res.json();
 }

--- a/src/github.js
+++ b/src/github.js
@@ -109,16 +109,32 @@ export async function listRepos(env) {
   return mapped;
 }
 
-export async function listIssues(env, fullRepo) {
-  const [owner, repoName] = parseFullRepo(fullRepo);
-  const issues = (await githubRequest(
-    env,
-    'GET',
-    `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
-      repoName
-    )}/issues?state=all&per_page=50`
-  )) || [];
+function mapIssueRow(i) {
+  return {
+    number: i.number,
+    title: i.title,
+    state: i.state,
+    url: i.html_url,
+    createdAt: i.created_at,
+  };
+}
 
+/**
+ * @param {{ recentClosed?: boolean }} [options]
+ *   recentClosed=false (standaard): alleen open issues (geen pull requests).
+ *   recentClosed=true: open + gesloten binnen de laatste 14 dagen (oude weergave).
+ */
+export async function listIssues(env, fullRepo, { recentClosed = false } = {}) {
+  const [owner, repoName] = parseFullRepo(fullRepo);
+  const base = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repoName)}/issues`;
+
+  if (!recentClosed) {
+    const issues =
+      (await githubRequest(env, 'GET', `${base}?state=open&per_page=100`)) || [];
+    return issues.filter((i) => !i.pull_request).map(mapIssueRow);
+  }
+
+  const issues = (await githubRequest(env, 'GET', `${base}?state=all&per_page=50`)) || [];
   const onlyIssues = issues.filter((i) => !i.pull_request);
   const twoWeeksAgo = Date.now() - 14 * 24 * 60 * 60 * 1000;
   return onlyIssues
@@ -127,13 +143,7 @@ export async function listIssues(env, fullRepo) {
       if (!i.closed_at) return true;
       return new Date(i.closed_at).getTime() > twoWeeksAgo;
     })
-    .map((i) => ({
-      number: i.number,
-      title: i.title,
-      state: i.state,
-      url: i.html_url,
-      createdAt: i.created_at,
-    }));
+    .map(mapIssueRow);
 }
 
 export async function createIssue(env, fullRepo, payload) {

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,9 @@ app.get('/api/repos/:repo/issues', async (req, res) => {
     if (!isRepoAllowed(fullRepo)) {
       return res.status(403).json({ error: 'Toegang tot deze repository is niet toegestaan' });
     }
-    res.json(await listIssues(env, fullRepo));
+    const rc = req.query.recentClosed;
+    const recentClosed = rc === '1' || String(rc).toLowerCase() === 'true';
+    res.json(await listIssues(env, fullRepo, { recentClosed }));
   } catch (err) {
     if (err instanceof URIError) {
       return res.status(400).json({ error: 'Ongeldige repository-parameter' });

--- a/src/pages/RepoPage.jsx
+++ b/src/pages/RepoPage.jsx
@@ -50,6 +50,7 @@ export default function RepoPage() {
   const [activeTemplate, setActiveTemplate] = useState(null);
   const [issues, setIssues] = useState(null);
   const [issuesError, setIssuesError] = useState(null);
+  const [showRecentClosed, setShowRecentClosed] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [message, setMessage] = useState(null);
 
@@ -72,12 +73,27 @@ export default function RepoPage() {
   }, []);
 
   function loadIssues() {
-    fetchIssues(repo)
+    setIssuesError(null);
+    fetchIssues(repo, { recentClosed: showRecentClosed })
       .then(setIssues)
       .catch((e) => setIssuesError(e.message));
   }
 
-  useEffect(loadIssues, [repo]);
+  useEffect(() => {
+    setIssues(null);
+    setIssuesError(null);
+    let cancelled = false;
+    fetchIssues(repo, { recentClosed: showRecentClosed })
+      .then((data) => {
+        if (!cancelled) setIssues(data);
+      })
+      .catch((e) => {
+        if (!cancelled) setIssuesError(e.message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, showRecentClosed]);
 
   function selectTemplate(t) {
     setActiveTemplate(t);
@@ -214,12 +230,24 @@ export default function RepoPage() {
 
         <div className="issues-section">
           <SectionDivider label="Bestaande meldingen" />
+          <div className="issues-filter">
+            <label className="issues-filter-label">
+              <input
+                type="checkbox"
+                checked={showRecentClosed}
+                onChange={(e) => setShowRecentClosed(e.target.checked)}
+              />
+              Toon ook recent gesloten meldingen (laatste 14 dagen)
+            </label>
+          </div>
           <div>
             {!issues && !issuesError && <div className="loading">Meldingen laden…</div>}
             {issuesError && <p className="error-box">{issuesError}</p>}
             {issues && issues.length === 0 && (
               <div className="loading" style={{ '--spinner-display': 'none' }}>
-                Er zijn nog geen meldingen voor deze website of app.
+                {showRecentClosed
+                  ? 'Er zijn nog geen meldingen voor deze website of app.'
+                  : 'Er zijn geen open meldingen. Vink hierboven aan om recent gesloten te tonen.'}
               </div>
             )}
             {issues && issues.map((issue) => (

--- a/src/styles.css
+++ b/src/styles.css
@@ -246,6 +246,9 @@ button.primary:disabled { opacity: 0.5; cursor: not-allowed; box-shadow: none; }
 
 /* Issues */
 .issues-section { margin-top: 3rem; }
+.issues-filter { margin: -0.25rem 0 1.25rem; }
+.issues-filter-label { display: inline-flex; align-items: center; gap: 0.65rem; font-size: 0.9rem; color: var(--muted); cursor: pointer; font-weight: 500; line-height: 1.4; }
+.issues-filter-label input { width: 1.05rem; height: 1.05rem; accent-color: var(--accent); cursor: pointer; flex-shrink: 0; }
 .issue-item { display: flex; align-items: center; gap: 1rem; padding: 1rem 0; border-bottom: 1px solid var(--border); font-size: 0.95rem; transition: background 0.2s ease; }
 .issue-item:hover { background: rgba(0,0,0,0.01); }
 .issue-item:last-child { border-bottom: none; }


### PR DESCRIPTION
## Samenvatting

- Standaard worden alleen **open** GitHub-issues getoond (`state=open`), zodat gesloten meldingen de lijst niet meer vullen.
- Met de checkbox **“Toon ook recent gesloten meldingen (laatste 14 dagen)”** keert het vorige gedrag terug: open issues plus gesloten issues die in de afgelopen 14 dagen zijn gesloten.
- De API ondersteunt optioneel `GET /api/repos/:repo/issues?recentClosed=1` voor dezelfde modus.

## Testen

- `npm run build` lokaal uitgevoerd.


Made with [Cursor](https://cursor.com)