### PR TITLE
feat(sentry): add relay endpoint POST /webhooks/sentry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -378,7 +378,8 @@ app.post('/api/intake/sporthengelo', async (req, res) => {
 // ─── Sentry webhook relay ─────────────────────────────────────────────────────
 
 app.post('/webhooks/sentry', express.raw({ type: '*/*' }), async (req, res) => {
-  const signature = req.headers['sentry-hook-signature'] ?? '';
+  const rawSig = req.headers['sentry-hook-signature'];
+  const signature = Array.isArray(rawSig) ? rawSig[0] : (rawSig ?? '');
   const { SENTRY_WEBHOOK_SECRET, PAPERCLIP_API_URL, PAPERCLIP_API_KEY, PAPERCLIP_ROUTINE_ID } =
     process.env;
 
@@ -405,14 +406,20 @@ app.post('/webhooks/sentry', express.raw({ type: '*/*' }), async (req, res) => {
     return res.status(400).end();
   }
 
-  const upstream = await fetch(`${PAPERCLIP_API_URL}/api/routines/${PAPERCLIP_ROUTINE_ID}/run`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${PAPERCLIP_API_KEY}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ source: 'webhook', payload }),
-  });
+  let upstream;
+  try {
+    upstream = await fetch(`${PAPERCLIP_API_URL}/api/routines/${PAPERCLIP_ROUTINE_ID}/run`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${PAPERCLIP_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ source: 'webhook', payload }),
+    });
+  } catch (err) {
+    console.error('[sentry relay] Network error reaching Paperclip', err);
+    return res.status(502).end();
+  }
 
   if (!upstream.ok) {
     console.error('[sentry relay] Upstream error', upstream.status, await upstream.text());

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { createHmac, timingSafeEqual } from 'crypto';
 import { getTemplates } from './templates.js';
 import { PROJECTS } from './config.js';
 
@@ -372,6 +373,53 @@ app.post('/api/intake/sporthengelo', async (req, res) => {
     console.error('[sporthengelo intake]', err);
     res.status(500).json({ error: 'Issue aanmaken mislukt' });
   }
+});
+
+// ─── Sentry webhook relay ─────────────────────────────────────────────────────
+
+app.post('/webhooks/sentry', express.raw({ type: '*/*' }), async (req, res) => {
+  const signature = req.headers['sentry-hook-signature'] ?? '';
+  const { SENTRY_WEBHOOK_SECRET, PAPERCLIP_API_URL, PAPERCLIP_API_KEY, PAPERCLIP_ROUTINE_ID } =
+    process.env;
+
+  if (!SENTRY_WEBHOOK_SECRET || !PAPERCLIP_API_URL || !PAPERCLIP_API_KEY || !PAPERCLIP_ROUTINE_ID) {
+    console.error('[sentry relay] Missing required env vars');
+    return res.status(503).end();
+  }
+
+  if (!signature.startsWith('sha256=')) {
+    return res.status(401).end();
+  }
+
+  const expected = 'sha256=' + createHmac('sha256', SENTRY_WEBHOOK_SECRET).update(req.body).digest('hex');
+  const sigBuf = Buffer.from(signature);
+  const expBuf = Buffer.from(expected);
+  if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
+    return res.status(401).end();
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(req.body);
+  } catch {
+    return res.status(400).end();
+  }
+
+  const upstream = await fetch(`${PAPERCLIP_API_URL}/api/routines/${PAPERCLIP_ROUTINE_ID}/run`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${PAPERCLIP_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ source: 'webhook', payload }),
+  });
+
+  if (!upstream.ok) {
+    console.error('[sentry relay] Upstream error', upstream.status, await upstream.text());
+    return res.status(502).end();
+  }
+
+  res.status(200).end();
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `POST /webhooks/sentry` to the Express backend — the right place for this integration (gh-issues is already the Paperclip integration hub).

- Validates `sentry-hook-signature` header using Node.js `crypto.timingSafeEqual` + HMAC-SHA256
- Forwards validated payload to the Paperclip Sentry Alert Handler routine via `/api/routines/{id}/run`
- Uses `express.raw()` to get the unmodified body before JSON parsing (required for valid HMAC)

## Required env vars (add to deployment config)

| Var | Source |
|---|---|
| `SENTRY_WEBHOOK_SECRET` | Sentry Internal Integration signing secret (via SPO-178) |
| `PAPERCLIP_ROUTINE_ID` | Routine ID from SPO-176 (HelpdeskAgent) |
| `PAPERCLIP_API_URL` | Already present |
| `PAPERCLIP_API_KEY` | Already present |

## Replaces

Reverts [sporthengelo#11](https://github.com/Sportvereniging-H-G-V/sporthengelo/pull/11) via [sporthengelo#12](https://github.com/Sportvereniging-H-G-V/sporthengelo/pull/12).

## Test plan

- [ ] Deploy and set the 2 new env vars
- [ ] `curl -X POST https://<host>/webhooks/sentry` with valid signature → 200
- [ ] Same with wrong signature → 401
- [ ] Verify a Paperclip routine execution issue is created

Closes SPO-177

🤖 Generated with [Claude Code](https://claude.com/claude-code)